### PR TITLE
feat: sync objectives via shared SPHAIRA API

### DIFF
--- a/index.html
+++ b/index.html
@@ -396,7 +396,8 @@
     ECLIPTICA assure la cohérence des plans d'action : toute mise à jour est envoyée instantanément dans <strong>SPHAIRA</strong> et <strong>ORIS</strong> pour maintenir un pilotage unifié.
   </footer>
 
-    <script>
+  <script src="shared/sphaira-data.js"></script>
+  <script>
     const CATEGORY_META = {
       developpement: { label: 'Développement', description: 'Livraisons produit SPHAIRA' },
       experience: { label: 'Expérience', description: 'Confort des responsables et équipes' },
@@ -406,120 +407,11 @@
     };
     const CATEGORY_ORDER = Object.keys(CATEGORY_META);
 
-    let OBJECTIVES = [
-      {
-        id: 'obj-2025-01',
-        date: '2025-01-18',
-        title: 'Stabiliser le noyau SPHAIRA',
-        cat: 'developpement',
-        icon: '🛠️',
-        lead: 'Équipe Produit',
-        desc: "Migration du moteur temps réel vers l'architecture Orion pour sécuriser les synchronisations entre nœuds.",
-        tasks: [
-          { id: 'task-1', title: 'Refonte du graphe des objectifs', owner: 'Core SPHAIRA', due: '2025-01-12', done: true },
-          { id: 'task-2', title: 'Diagnostics de performance', owner: 'Qualité', due: '2025-01-18', done: false },
-          { id: 'task-3', title: 'Plan de rollback automatisé', owner: 'Ops', due: '2025-01-20', done: false }
-        ]
-      },
-      {
-        id: 'obj-2025-03',
-        date: '2025-03-05',
-        title: 'Aligner les parcours ORIS ↔︎ SPHAIRA',
-        cat: 'alignement',
-        icon: '🔄',
-        lead: 'Ops Produit',
-        desc: "Unification des points de contact et mise à jour des webhooks pour une remontée instantanée des objectifs.",
-        tasks: [
-          { id: 'task-4', title: 'Audit des webhooks existants', owner: 'ORIS', due: '2025-02-20', done: true },
-          { id: 'task-5', title: 'Mapping des statuts partagés', owner: 'SPHAIRA', due: '2025-03-05', done: false },
-          { id: 'task-6', title: 'Tests bout en bout ORIS', owner: 'Qualité', due: '2025-03-12', done: false }
-        ]
-      },
-      {
-        id: 'obj-2025-04',
-        date: '2025-04-22',
-        title: "Expérience responsable d'objectif",
-        cat: 'experience',
-        icon: '🎯',
-        lead: 'Design Ops',
-        desc: "Création d'une vue dédiée pour clarifier la progression des tâches assignées et faciliter les décisions.",
-        tasks: [
-          { id: 'task-7', title: 'Interviews responsables pilotes', owner: 'Design', due: '2025-04-05', done: true },
-          { id: 'task-8', title: 'Prototype interactif', owner: 'Design Ops', due: '2025-04-12', done: true },
-          { id: 'task-9', title: 'Déploiement contrôlé', owner: 'Produit', due: '2025-04-22', done: false }
-        ]
-      },
-      {
-        id: 'obj-2025-06',
-        date: '2025-06-17',
-        title: 'Automatiser la gouvernance des droits',
-        cat: 'operations',
-        icon: '🛡️',
-        lead: 'Sécurité & Conformité',
-        desc: "Mise en place de profils dynamiques et d'un audit trail partagé entre SPHAIRA et ORIS.",
-        tasks: [
-          { id: 'task-10', title: 'Catalogue des rôles', owner: 'Sécurité', due: '2025-05-30', done: true },
-          { id: 'task-11', title: "Développement du moteur d'habilitations", owner: 'Back-end', due: '2025-06-14', done: false },
-          { id: 'task-12', title: 'Recette RGPD conjointe', owner: 'Legal', due: '2025-06-25', done: false }
-        ]
-      },
-      {
-        id: 'obj-2025-07',
-        date: '2025-07-29',
-        title: "Campagne d'adoption multi-canale",
-        cat: 'lancement',
-        icon: '📣',
-        lead: 'Marketing Produit',
-        desc: 'Activation progressive des comptes clés avec contenus ciblés et webinaires synchronisés.',
-        tasks: [
-          { id: 'task-13', title: 'Sélection des segments prioritaires', owner: 'Marketing', due: '2025-07-05', done: true },
-          { id: 'task-14', title: 'Kit de communication co-marquée', owner: 'Brand', due: '2025-07-18', done: false },
-          { id: 'task-15', title: 'Webinaire lancement', owner: 'ORIS', due: '2025-07-29', done: false }
-        ]
-      },
-      {
-        id: 'obj-2025-09',
-        date: '2025-09-14',
-        title: 'Connecteur données de pilotage',
-        cat: 'operations',
-        icon: '📊',
-        lead: 'Data Intelligence',
-        desc: "Centralisation des indicateurs d'usage SPHAIRA & ORIS pour piloter les OKR en continu.",
-        tasks: [
-          { id: 'task-16', title: 'Spécifications API métriques', owner: 'Data', due: '2025-08-20', done: true },
-          { id: 'task-17', title: 'Pipelines vers le data lake', owner: 'Engineering', due: '2025-09-10', done: false },
-          { id: 'task-18', title: 'Tableaux de bord ECLIPTICA', owner: 'Ops Produit', due: '2025-09-25', done: false }
-        ]
-      },
-      {
-        id: 'obj-2025-10',
-        date: '2025-10-21',
-        title: 'Portail partenaires ORIS',
-        cat: 'lancement',
-        icon: '🌐',
-        lead: 'Alliances',
-        desc: "Ouverture d'un espace partagé pour suivre la contribution des partenaires et les objectifs associés.",
-        tasks: [
-          { id: 'task-19', title: 'Architecture du portail', owner: 'Front-end', due: '2025-10-05', done: true },
-          { id: 'task-20', title: 'Catalogue des offres partenaires', owner: 'Alliances', due: '2025-10-18', done: false },
-          { id: 'task-21', title: 'Synchronisation des rôles partenaires', owner: 'Sécurité', due: '2025-10-21', done: false }
-        ]
-      },
-      {
-        id: 'obj-2025-12',
-        date: '2025-12-09',
-        title: 'Clôture feuille de route 2025',
-        cat: 'alignement',
-        icon: '🌀',
-        lead: 'Direction Produit',
-        desc: "Consolidation des enseignements 2025 et cadrage des objectifs 2026 partagés entre SPHAIRA et ORIS.",
-        tasks: [
-          { id: 'task-22', title: 'Analyse des OKR', owner: 'Direction Produit', due: '2025-11-30', done: false },
-          { id: 'task-23', title: 'Atelier vision 2026', owner: 'Leadership', due: '2025-12-05', done: false },
-          { id: 'task-24', title: 'Publication récapitulatif', owner: 'Communication', due: '2025-12-12', done: false }
-        ]
-      }
-    ];
+    const SPHAIRA_API_BASE_URL = window.SPHAIRA_API_BASE || 'memory://sphaira';
+    const SPHAIRA_STORAGE_KEY = window.SPHAIRA_STORAGE_KEY || 'sphaira:objectives';
+
+    let OBJECTIVES = [];
+    let objectivesLoadingPromise = null;
 
     const start = new Date('2025-01-01T00:00:00');
     const end   = new Date('2025-12-31T23:59:59');
@@ -542,6 +434,106 @@
 
     function uid(prefix){
       return `${prefix}-${Math.random().toString(36).slice(2,8)}${Date.now().toString(36).slice(-2)}`;
+    }
+
+    function normalizeObjective(obj){
+      if(!obj || typeof obj !== 'object') return null;
+      const tasks = Array.isArray(obj.tasks) ? obj.tasks.map(task => {
+        if(!task || typeof task !== 'object') return null;
+        return {
+          id: task.id || uid('task'),
+          title: String(task.title ?? '').trim(),
+          owner: String(task.owner ?? '').trim(),
+          due: task.due ? String(task.due) : '',
+          done: Boolean(task.done)
+        };
+      }).filter(Boolean) : [];
+      return {
+        id: obj.id || uid('obj'),
+        date: obj.date ? String(obj.date) : new Date().toISOString().slice(0,10),
+        title: String(obj.title ?? '').trim() || 'Objectif sans titre',
+        cat: String(obj.cat ?? 'developpement'),
+        icon: obj.icon ? String(obj.icon) : '🗂️',
+        lead: obj.lead ? String(obj.lead) : '',
+        desc: obj.desc ? String(obj.desc) : '',
+        tasks
+      };
+    }
+
+    async function loadObjectivesFromSphaira(){
+      if(objectivesLoadingPromise){
+        return objectivesLoadingPromise;
+      }
+
+      syncStatusMessage.textContent = 'Chargement depuis SPHAIRA…';
+      objectivesLoadingPromise = (async () => {
+        try {
+          const response = await fetch(`${SPHAIRA_API_BASE_URL}/objectives`);
+          let payload;
+          if(response.ok){
+            payload = await response.json();
+          } else {
+            let message = response.statusText || `Code ${response.status}`;
+            try {
+              const errorPayload = await response.json();
+              if(errorPayload && errorPayload.error){
+                message = errorPayload.error;
+              }
+            } catch(_){}
+            throw new Error(message);
+          }
+
+          const normalized = Array.isArray(payload) ? payload.map(normalizeObjective).filter(Boolean) : [];
+          normalized.sort((a, b) => new Date(a.date) - new Date(b.date));
+          OBJECTIVES = normalized;
+          refreshTimelines();
+          const ts = new Date().toLocaleTimeString('fr-FR', { hour:'2-digit', minute:'2-digit' });
+          syncStatusMessage.textContent = `Synchronisé avec SPHAIRA — ${ts}`;
+        } catch(error){
+          console.error('Erreur lors du chargement des objectifs SPHAIRA', error);
+          syncStatusMessage.textContent = `Erreur de synchronisation SPHAIRA : ${error.message}`;
+        } finally {
+          objectivesLoadingPromise = null;
+        }
+      })();
+
+      return objectivesLoadingPromise;
+    }
+
+    async function persistObjectiveToSphaira(objective, isUpdate){
+      const url = isUpdate
+        ? `${SPHAIRA_API_BASE_URL}/objectives/${encodeURIComponent(objective.id)}`
+        : `${SPHAIRA_API_BASE_URL}/objectives`;
+      const response = await fetch(url, {
+        method: isUpdate ? 'PUT' : 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(objective)
+      });
+      if(!response.ok){
+        let message = response.statusText || `Code ${response.status}`;
+        try {
+          const errorPayload = await response.json();
+          if(errorPayload && errorPayload.error){
+            message = errorPayload.error;
+          }
+        } catch(_){}
+        throw new Error(message);
+      }
+      return response.json();
+    }
+
+    async function deleteObjectiveFromSphaira(id){
+      const response = await fetch(`${SPHAIRA_API_BASE_URL}/objectives/${encodeURIComponent(id)}`, { method: 'DELETE' });
+      if(!response.ok){
+        let message = response.statusText || `Code ${response.status}`;
+        try {
+          const errorPayload = await response.json();
+          if(errorPayload && errorPayload.error){
+            message = errorPayload.error;
+          }
+        } catch(_){}
+        throw new Error(message);
+      }
     }
 
     function fmtDate(d, withYear = false){
@@ -990,7 +982,7 @@
       applyFilter(currentFilter);
     }
 
-    objectiveForm.addEventListener('submit', (event) => {
+    objectiveForm.addEventListener('submit', async (event) => {
       event.preventDefault();
       const formData = new FormData(objectiveForm);
       const baseId = currentObjectiveId ?? uid('obj');
@@ -1022,28 +1014,32 @@
 
       const existingIndex = OBJECTIVES.findIndex(obj => obj.id === baseId);
       const action = existingIndex > -1 ? 'mise à jour' : 'création';
-      if(existingIndex > -1){
-        OBJECTIVES[existingIndex] = objective;
-      } else {
-        OBJECTIVES.push(objective);
+      try {
+        await persistObjectiveToSphaira(objective, existingIndex > -1);
+        syncWithSystems(action, objective);
+        closePanel();
+        await loadObjectivesFromSphaira();
+      } catch(error){
+        console.error('Impossible de synchroniser l\'objectif avec SPHAIRA', error);
+        syncStatusMessage.textContent = `Erreur de synchronisation SPHAIRA : ${error.message}`;
       }
-      OBJECTIVES.sort((a, b) => new Date(a.date) - new Date(b.date));
-
-      syncWithSystems(action, objective);
-      closePanel();
-      refreshTimelines();
     });
 
-    deleteObjectiveBtn.addEventListener('click', () => {
+    deleteObjectiveBtn.addEventListener('click', async () => {
       if(!currentObjectiveId) return;
       const target = OBJECTIVES.find(obj => obj.id === currentObjectiveId);
       if(!target) return;
       const confirmation = window.confirm(`Supprimer l'objectif « ${target.title} » ?`);
       if(!confirmation) return;
-      OBJECTIVES = OBJECTIVES.filter(obj => obj.id !== currentObjectiveId);
-      syncWithSystems('suppression', target);
-      closePanel();
-      refreshTimelines();
+      try {
+        await deleteObjectiveFromSphaira(currentObjectiveId);
+        syncWithSystems('suppression', target);
+        closePanel();
+        await loadObjectivesFromSphaira();
+      } catch(error){
+        console.error('Impossible de supprimer l\'objectif dans SPHAIRA', error);
+        syncStatusMessage.textContent = `Erreur de synchronisation SPHAIRA : ${error.message}`;
+      }
     });
 
     addTaskBtn.addEventListener('click', () => addTaskRow({}));
@@ -1056,7 +1052,17 @@
       }
     });
 
-    refreshTimelines();
+    window.addEventListener('sphaira:objectives', () => {
+      loadObjectivesFromSphaira();
+    });
+
+    window.addEventListener('storage', (event) => {
+      if(event.key === SPHAIRA_STORAGE_KEY){
+        loadObjectivesFromSphaira();
+      }
+    });
+
+    loadObjectivesFromSphaira();
     attachFilters();
     attachMonthNav();
     attachViewSwitch();

--- a/shared/sphaira-data.js
+++ b/shared/sphaira-data.js
@@ -1,0 +1,329 @@
+(function(global){
+  const API_BASE = global.SPHAIRA_API_BASE || 'memory://sphaira';
+  const STORAGE_KEY = global.SPHAIRA_STORAGE_KEY || 'sphaira:objectives';
+  global.SPHAIRA_API_BASE = API_BASE;
+  global.SPHAIRA_STORAGE_KEY = STORAGE_KEY;
+
+  const DEFAULT_OBJECTIVES = global.SPHAIRA_DEFAULT_OBJECTIVES || [
+    {
+      id: 'obj-2025-01',
+      date: '2025-01-18',
+      title: 'Stabiliser le noyau SPHAIRA',
+      cat: 'developpement',
+      icon: '🛠️',
+      lead: 'Équipe Produit',
+      desc: "Migration du moteur temps réel vers l'architecture Orion pour sécuriser les synchronisations entre nœuds.",
+      tasks: [
+        { id: 'task-1', title: 'Refonte du graphe des objectifs', owner: 'Core SPHAIRA', due: '2025-01-12', done: true },
+        { id: 'task-2', title: 'Diagnostics de performance', owner: 'Qualité', due: '2025-01-18', done: false },
+        { id: 'task-3', title: 'Plan de rollback automatisé', owner: 'Ops', due: '2025-01-20', done: false }
+      ]
+    },
+    {
+      id: 'obj-2025-03',
+      date: '2025-03-05',
+      title: 'Aligner les parcours ORIS ↔︎ SPHAIRA',
+      cat: 'alignement',
+      icon: '🔄',
+      lead: 'Ops Produit',
+      desc: "Unification des points de contact et mise à jour des webhooks pour une remontée instantanée des objectifs.",
+      tasks: [
+        { id: 'task-4', title: 'Audit des webhooks existants', owner: 'ORIS', due: '2025-02-20', done: true },
+        { id: 'task-5', title: 'Mapping des statuts partagés', owner: 'SPHAIRA', due: '2025-03-05', done: false },
+        { id: 'task-6', title: 'Tests bout en bout ORIS', owner: 'Qualité', due: '2025-03-12', done: false }
+      ]
+    },
+    {
+      id: 'obj-2025-04',
+      date: '2025-04-22',
+      title: "Expérience responsable d'objectif",
+      cat: 'experience',
+      icon: '🎯',
+      lead: 'Design Ops',
+      desc: "Création d'une vue dédiée pour clarifier la progression des tâches assignées et faciliter les décisions.",
+      tasks: [
+        { id: 'task-7', title: 'Interviews responsables pilotes', owner: 'Design', due: '2025-04-05', done: true },
+        { id: 'task-8', title: 'Prototype interactif', owner: 'Design Ops', due: '2025-04-12', done: true },
+        { id: 'task-9', title: 'Déploiement contrôlé', owner: 'Produit', due: '2025-04-22', done: false }
+      ]
+    },
+    {
+      id: 'obj-2025-06',
+      date: '2025-06-17',
+      title: 'Automatiser la gouvernance des droits',
+      cat: 'operations',
+      icon: '🛡️',
+      lead: 'Sécurité & Conformité',
+      desc: "Mise en place de profils dynamiques et d'un audit trail partagé entre SPHAIRA et ORIS.",
+      tasks: [
+        { id: 'task-10', title: 'Catalogue des rôles', owner: 'Sécurité', due: '2025-05-30', done: true },
+        { id: 'task-11', title: "Développement du moteur d'habilitations", owner: 'Back-end', due: '2025-06-14', done: false },
+        { id: 'task-12', title: 'Recette RGPD conjointe', owner: 'Legal', due: '2025-06-25', done: false }
+      ]
+    },
+    {
+      id: 'obj-2025-07',
+      date: '2025-07-29',
+      title: "Campagne d'adoption multi-canale",
+      cat: 'lancement',
+      icon: '📣',
+      lead: 'Marketing Produit',
+      desc: 'Activation progressive des comptes clés avec contenus ciblés et webinaires synchronisés.',
+      tasks: [
+        { id: 'task-13', title: 'Sélection des segments prioritaires', owner: 'Marketing', due: '2025-07-05', done: true },
+        { id: 'task-14', title: 'Kit de communication co-marquée', owner: 'Brand', due: '2025-07-18', done: false },
+        { id: 'task-15', title: 'Webinaire lancement', owner: 'ORIS', due: '2025-07-29', done: false }
+      ]
+    },
+    {
+      id: 'obj-2025-09',
+      date: '2025-09-14',
+      title: 'Connecteur données de pilotage',
+      cat: 'operations',
+      icon: '📊',
+      lead: 'Data Intelligence',
+      desc: "Centralisation des indicateurs d'usage SPHAIRA & ORIS pour piloter les OKR en continu.",
+      tasks: [
+        { id: 'task-16', title: 'Spécifications API métriques', owner: 'Data', due: '2025-08-20', done: true },
+        { id: 'task-17', title: 'Pipelines vers le data lake', owner: 'Engineering', due: '2025-09-10', done: false },
+        { id: 'task-18', title: 'Tableaux de bord ECLIPTICA', owner: 'Ops Produit', due: '2025-09-25', done: false }
+      ]
+    },
+    {
+      id: 'obj-2025-10',
+      date: '2025-10-21',
+      title: 'Portail partenaires ORIS',
+      cat: 'lancement',
+      icon: '🌐',
+      lead: 'Alliances',
+      desc: "Ouverture d'un espace partagé pour suivre la contribution des partenaires et les objectifs associés.",
+      tasks: [
+        { id: 'task-19', title: 'Architecture du portail', owner: 'Front-end', due: '2025-10-05', done: true },
+        { id: 'task-20', title: 'Catalogue des offres partenaires', owner: 'Alliances', due: '2025-10-18', done: false },
+        { id: 'task-21', title: 'Synchronisation des rôles partenaires', owner: 'Sécurité', due: '2025-10-21', done: false }
+      ]
+    },
+    {
+      id: 'obj-2025-12',
+      date: '2025-12-09',
+      title: 'Clôture feuille de route 2025',
+      cat: 'alignement',
+      icon: '🌀',
+      lead: 'Direction Produit',
+      desc: "Consolidation des enseignements 2025 et cadrage des objectifs 2026 partagés entre SPHAIRA et ORIS.",
+      tasks: [
+        { id: 'task-22', title: 'Analyse des OKR', owner: 'Direction Produit', due: '2025-11-30', done: false },
+        { id: 'task-23', title: 'Atelier vision 2026', owner: 'Leadership', due: '2025-12-05', done: false },
+        { id: 'task-24', title: 'Publication récapitulatif', owner: 'Communication', due: '2025-12-12', done: false }
+      ]
+    }
+  ];
+  global.SPHAIRA_DEFAULT_OBJECTIVES = DEFAULT_OBJECTIVES;
+
+  const originalFetch = global.fetch ? global.fetch.bind(global) : null;
+
+  const clone = (value) => JSON.parse(JSON.stringify(value));
+  const generateId = (prefix) => `${prefix}-${Math.random().toString(36).slice(2,8)}${Date.now().toString(36).slice(-4)}`;
+
+  const sanitizeTask = (task) => {
+    if(!task || typeof task !== 'object') return null;
+    return {
+      id: task.id || generateId('task'),
+      title: String(task.title ?? '').trim(),
+      owner: String(task.owner ?? '').trim(),
+      due: task.due ? String(task.due) : '',
+      done: Boolean(task.done)
+    };
+  };
+
+  const sanitizeObjective = (obj) => {
+    if(!obj || typeof obj !== 'object') return null;
+    const tasks = Array.isArray(obj.tasks) ? obj.tasks.map(sanitizeTask).filter(Boolean) : [];
+    return {
+      id: obj.id || generateId('obj'),
+      date: obj.date ? String(obj.date) : new Date().toISOString().slice(0,10),
+      title: String(obj.title ?? '').trim(),
+      cat: String(obj.cat ?? 'developpement'),
+      icon: obj.icon ? String(obj.icon) : '🗂️',
+      lead: obj.lead ? String(obj.lead) : '',
+      desc: obj.desc ? String(obj.desc) : '',
+      tasks
+    };
+  };
+
+  const loadStore = () => {
+    try {
+      const raw = global.localStorage.getItem(STORAGE_KEY);
+      if(raw){
+        const parsed = JSON.parse(raw);
+        if(Array.isArray(parsed)){
+          return parsed.map(sanitizeObjective).filter(Boolean);
+        }
+      }
+    } catch(err){
+      console.warn('Impossible de charger les objectifs SPHAIRA depuis le stockage local.', err);
+    }
+    const defaults = DEFAULT_OBJECTIVES.map(sanitizeObjective).filter(Boolean);
+    try {
+      global.localStorage.setItem(STORAGE_KEY, JSON.stringify(defaults));
+    } catch(err){
+      console.warn('Impossible de persister les objectifs par défaut SPHAIRA.', err);
+    }
+    return defaults;
+  };
+
+  let store = loadStore();
+
+  const persist = () => {
+    try {
+      global.localStorage.setItem(STORAGE_KEY, JSON.stringify(store));
+    } catch(err){
+      console.warn('Impossible de sauvegarder les objectifs SPHAIRA.', err);
+    }
+  };
+
+  const sortStore = () => {
+    store.sort((a, b) => new Date(a.date) - new Date(b.date));
+  };
+
+  const makeJsonResponse = (data, init = {}) => {
+    return new Response(data === undefined ? null : JSON.stringify(data), {
+      status: init.status ?? 200,
+      statusText: init.statusText,
+      headers: {
+        'Content-Type': 'application/json',
+        ...(init.headers || {})
+      }
+    });
+  };
+
+  const badRequest = (message) => makeJsonResponse({ error: message }, { status: 400 });
+  const notFound = () => makeJsonResponse({ error: 'Not found' }, { status: 404 });
+
+  const readBody = async (resource, options) => {
+    if(options && options.body !== undefined){
+      const body = options.body;
+      if(typeof body === 'string') return body;
+      if(body instanceof Blob) return await body.text();
+      if(body instanceof FormData){
+        const result = {};
+        body.forEach((value, key) => { result[key] = value; });
+        return JSON.stringify(result);
+      }
+      if(body && typeof body === 'object' && typeof body.text === 'function'){
+        return await body.text();
+      }
+      return body;
+    }
+    if(resource && typeof resource.text === 'function'){
+      return await resource.text();
+    }
+    return null;
+  };
+
+  const original = originalFetch || (resource => Promise.reject(new Error('fetch non disponible')));
+
+  global.SPHAIRA_DATA_BRIDGE = {
+    getObjectives: () => clone(store),
+    storageKey: STORAGE_KEY,
+    apiBase: API_BASE
+  };
+
+  global.fetch = async function(resource, options = {}){
+    const request = typeof resource === 'string' ? null : resource;
+    const url = typeof resource === 'string' ? resource : resource.url;
+    const method = (options.method || (request && request.method) || 'GET').toUpperCase();
+
+    if(url && url.startsWith(API_BASE)){
+      const path = url.slice(API_BASE.length) || '/';
+
+      if(path === '/objectives' && method === 'GET'){
+        sortStore();
+        return makeJsonResponse(clone(store));
+      }
+
+      if(path === '/objectives' && method === 'POST'){
+        const raw = await readBody(request, options);
+        if(!raw) return badRequest('Corps requis');
+        let payload;
+        try {
+          payload = typeof raw === 'string' ? JSON.parse(raw) : raw;
+        } catch(err){
+          return badRequest('JSON invalide');
+        }
+        const objective = sanitizeObjective(payload);
+        const existingIndex = store.findIndex(item => item.id === objective.id);
+        if(existingIndex > -1){
+          store[existingIndex] = objective;
+        } else {
+          store.push(objective);
+        }
+        sortStore();
+        persist();
+        global.dispatchEvent(new CustomEvent('sphaira:objectives', {
+          detail: { type: existingIndex > -1 ? 'updated' : 'created', objective: clone(objective) }
+        }));
+        return makeJsonResponse(objective, { status: existingIndex > -1 ? 200 : 201 });
+      }
+
+      if(path.startsWith('/objectives/')){
+        const segments = path.split('/').filter(Boolean);
+        const id = decodeURIComponent(segments[1] || '');
+        const index = store.findIndex(item => item.id === id);
+
+        if(method === 'PUT'){
+          const raw = await readBody(request, options);
+          if(!raw) return badRequest('Corps requis');
+          let payload;
+          try {
+            payload = typeof raw === 'string' ? JSON.parse(raw) : raw;
+          } catch(err){
+            return badRequest('JSON invalide');
+          }
+          const objective = sanitizeObjective({ ...payload, id });
+          if(index > -1){
+            store[index] = objective;
+          } else {
+            store.push(objective);
+          }
+          sortStore();
+          persist();
+          global.dispatchEvent(new CustomEvent('sphaira:objectives', {
+            detail: { type: index > -1 ? 'updated' : 'created', objective: clone(objective) }
+          }));
+          return makeJsonResponse(objective, { status: index > -1 ? 200 : 201 });
+        }
+
+        if(method === 'DELETE'){
+          if(index === -1){
+            return notFound();
+          }
+          const [removed] = store.splice(index, 1);
+          persist();
+          global.dispatchEvent(new CustomEvent('sphaira:objectives', {
+            detail: { type: 'deleted', objective: clone(removed) }
+          }));
+          return makeJsonResponse({ id });
+        }
+      }
+
+      return notFound();
+    }
+
+    return original(resource, options);
+  };
+
+  global.addEventListener('storage', (event) => {
+    if(event.key === STORAGE_KEY && event.newValue){
+      try {
+        const parsed = JSON.parse(event.newValue);
+        if(Array.isArray(parsed)){
+          store = parsed.map(sanitizeObjective).filter(Boolean);
+          sortStore();
+        }
+      } catch(err){
+        console.warn('Impossible de synchroniser les objectifs SPHAIRA depuis le stockage.', err);
+      }
+    }
+  });
+})(window);

--- a/sphaira/index.html
+++ b/sphaira/index.html
@@ -1,0 +1,437 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="utf-8">
+  <title>SPHAIRA — Console de synchronisation</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    :root{
+      color-scheme: dark;
+      --bg:#040810;
+      --panel:#0d1625;
+      --accent:#5bd8ff;
+      --accent-strong:#89f1ff;
+      --muted:#7f8ba3;
+      --text:#f5faff;
+      --border:rgba(255,255,255,.08);
+    }
+    *{box-sizing:border-box;font-family:"Inter",system-ui,sans-serif;}
+    body{
+      margin:0;
+      min-height:100vh;
+      background:radial-gradient(circle at top, rgba(22,70,130,.5), transparent 55%), #030712;
+      color:var(--text);
+      padding:40px 20px 80px;
+      display:flex;
+      justify-content:center;
+    }
+    main{
+      width:min(960px, 100%);
+      display:flex;
+      flex-direction:column;
+      gap:32px;
+    }
+    header h1{
+      margin:0;
+      font-size:28px;
+      font-weight:700;
+      letter-spacing:.04em;
+    }
+    header p{
+      margin:12px 0 0;
+      max-width:720px;
+      color:var(--muted);
+      line-height:1.5;
+    }
+    section{
+      padding:24px;
+      border-radius:16px;
+      background:linear-gradient(180deg, rgba(13,22,37,.92), rgba(4,10,20,.92));
+      border:1px solid var(--border);
+      box-shadow:0 20px 50px rgba(0,0,0,.35);
+    }
+    h2{
+      margin:0 0 16px;
+      font-size:18px;
+      letter-spacing:.08em;
+      text-transform:uppercase;
+      color:var(--accent-strong);
+    }
+    #statusBar{
+      display:flex;
+      align-items:center;
+      gap:12px;
+      font-size:14px;
+      color:var(--muted);
+    }
+    #statusBar .pulse{
+      width:12px;
+      height:12px;
+      border-radius:50%;
+      background:var(--accent);
+      box-shadow:0 0 18px rgba(91,216,255,.6);
+      animation:pulse 2.4s ease-in-out infinite;
+    }
+    #statusMessage[data-tone="error"]{color:#ff9d9d;}
+    #statusMessage[data-tone="success"]{color:#8fffd2;}
+    @keyframes pulse{
+      0%,100%{transform:scale(.9); opacity:.5;}
+      50%{transform:scale(1.15); opacity:1;}
+    }
+    .objective-card{
+      border:1px solid var(--border);
+      border-radius:14px;
+      padding:16px;
+      margin-bottom:16px;
+      background:rgba(5,12,22,.85);
+    }
+    .objective-card:last-child{margin-bottom:0;}
+    .objective-card h3{
+      margin:0 0 8px;
+      font-size:18px;
+      display:flex;
+      align-items:center;
+      gap:10px;
+    }
+    .objective-meta{
+      display:flex;
+      flex-wrap:wrap;
+      gap:10px;
+      font-size:13px;
+      color:var(--muted);
+      margin-bottom:12px;
+    }
+    .objective-card ul{
+      margin:0;
+      padding-left:20px;
+      display:grid;
+      gap:6px;
+    }
+    .objective-card li{
+      font-size:13px;
+      color:var(--text);
+    }
+    .empty{
+      margin:0;
+      color:var(--muted);
+      font-size:14px;
+      text-align:center;
+    }
+    form{
+      display:grid;
+      gap:14px;
+    }
+    label{
+      display:grid;
+      gap:6px;
+      font-size:13px;
+      color:var(--muted);
+    }
+    input, select, textarea{
+      padding:10px 12px;
+      border-radius:10px;
+      border:1px solid var(--border);
+      background:rgba(4,12,22,.9);
+      color:var(--text);
+      font-size:14px;
+    }
+    textarea{min-height:80px;}
+    .actions{
+      display:flex;
+      justify-content:flex-end;
+    }
+    button{
+      padding:10px 18px;
+      border-radius:999px;
+      border:1px solid rgba(91,216,255,.45);
+      background:linear-gradient(90deg, rgba(91,216,255,.25), rgba(91,216,255,.05));
+      color:var(--text);
+      text-transform:uppercase;
+      letter-spacing:.08em;
+      font-weight:600;
+      cursor:pointer;
+      transition:transform .2s ease, border-color .2s ease;
+    }
+    button[disabled]{
+      opacity:.5;
+      cursor:not-allowed;
+    }
+    button:not([disabled]):hover{
+      transform:translateY(-1px);
+      border-color:rgba(137,241,255,.85);
+    }
+    @media(max-width:640px){
+      section{padding:20px;}
+      header h1{font-size:24px;}
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <h1>SPHAIRA — Console de synchronisation</h1>
+      <p>Cette console expose les objectifs partagés entre SPHAIRA et ECLIPTICA. Toute création de tâche est immédiatement persistée dans la source commune puis récupérée par ECLIPTICA.</p>
+    </header>
+
+    <section id="statusBar">
+      <span class="pulse" aria-hidden="true"></span>
+      <span id="statusMessage">Initialisation de la synchronisation…</span>
+    </section>
+
+    <section>
+      <h2>Objectifs actifs</h2>
+      <div id="objectivesContainer"></div>
+    </section>
+
+    <section>
+      <h2>Créer une tâche</h2>
+      <form id="taskForm">
+        <label>
+          Objectif
+          <select id="objectiveSelect" name="objectiveId" required></select>
+        </label>
+        <label>
+          Titre de la tâche
+          <input type="text" id="taskTitle" name="title" placeholder="Ex : Déployer les APIs ORIS" required>
+        </label>
+        <label>
+          Responsable
+          <input type="text" id="taskOwner" name="owner" placeholder="Ex : Ops Produit">
+        </label>
+        <label>
+          Échéance
+          <input type="date" id="taskDue" name="due">
+        </label>
+        <label>
+          Statut
+          <select id="taskStatus" name="status">
+            <option value="todo">À planifier</option>
+            <option value="done">Terminé</option>
+          </select>
+        </label>
+        <div class="actions">
+          <button type="submit">Créer la tâche</button>
+        </div>
+      </form>
+    </section>
+  </main>
+
+  <script src="../shared/sphaira-data.js"></script>
+  <script>
+    const API_BASE = window.SPHAIRA_API_BASE || 'memory://sphaira';
+    const STORAGE_KEY = window.SPHAIRA_STORAGE_KEY || 'sphaira:objectives';
+
+    const statusMessage = document.getElementById('statusMessage');
+    const objectivesContainer = document.getElementById('objectivesContainer');
+    const objectiveSelect = document.getElementById('objectiveSelect');
+    const taskForm = document.getElementById('taskForm');
+    const submitButton = taskForm.querySelector('button[type="submit"]');
+
+    let loadPromise = null;
+
+    function setStatus(message, tone = 'info'){
+      statusMessage.textContent = message;
+      statusMessage.dataset.tone = tone;
+    }
+
+    function taskSummary(tasks){
+      if(!Array.isArray(tasks) || tasks.length === 0){
+        return 'Aucune tâche';
+      }
+      const done = tasks.filter(task => task.done).length;
+      return `${done}/${tasks.length} tâche${tasks.length > 1 ? 's' : ''} complétée${tasks.length > 1 ? 's' : ''}`;
+    }
+
+    function renderObjectives(objectives){
+      objectivesContainer.innerHTML = '';
+      if(!objectives.length){
+        const empty = document.createElement('p');
+        empty.className = 'empty';
+        empty.textContent = 'Aucun objectif disponible.';
+        objectivesContainer.appendChild(empty);
+        return;
+      }
+
+      const sorted = [...objectives].sort((a, b) => new Date(a.date) - new Date(b.date));
+      sorted.forEach(obj => {
+        const card = document.createElement('article');
+        card.className = 'objective-card';
+        card.innerHTML = `
+          <h3>${obj.icon || '🗂️'} ${obj.title}</h3>
+          <div class="objective-meta">
+            <span>${new Date(obj.date).toLocaleDateString('fr-FR')}</span>
+            ${obj.lead ? `<span>👤 ${obj.lead}</span>` : ''}
+            <span>${taskSummary(obj.tasks)}</span>
+          </div>
+        `;
+        const list = document.createElement('ul');
+        if(Array.isArray(obj.tasks) && obj.tasks.length){
+          obj.tasks.forEach(task => {
+            const item = document.createElement('li');
+            const status = task.done ? '✓' : '•';
+            const due = task.due ? ` — ${new Date(task.due).toLocaleDateString('fr-FR')}` : '';
+            const owner = task.owner ? ` (${task.owner})` : '';
+            item.textContent = `${status} ${task.title}${owner}${due}`;
+            list.appendChild(item);
+          });
+        } else {
+          const none = document.createElement('li');
+          none.textContent = 'Aucune tâche associée';
+          list.appendChild(none);
+        }
+        card.appendChild(list);
+        objectivesContainer.appendChild(card);
+      });
+    }
+
+    function populateObjectiveSelect(objectives){
+      objectiveSelect.innerHTML = '';
+      const sorted = [...objectives].sort((a, b) => new Date(a.date) - new Date(b.date));
+      if(!sorted.length){
+        const option = document.createElement('option');
+        option.value = '';
+        option.textContent = 'Aucun objectif disponible';
+        objectiveSelect.appendChild(option);
+        objectiveSelect.disabled = true;
+        submitButton.disabled = true;
+        return;
+      }
+
+      objectiveSelect.disabled = false;
+      submitButton.disabled = false;
+      sorted.forEach(obj => {
+        const option = document.createElement('option');
+        option.value = obj.id;
+        const date = new Date(obj.date);
+        option.textContent = `${date.toLocaleDateString('fr-FR')} — ${obj.title}`;
+        objectiveSelect.appendChild(option);
+      });
+    }
+
+    async function loadObjectives(){
+      if(loadPromise){
+        return loadPromise;
+      }
+      setStatus('Chargement des objectifs…', 'info');
+      loadPromise = (async () => {
+        try {
+          const response = await fetch(`${API_BASE}/objectives`);
+          let payload;
+          if(response.ok){
+            payload = await response.json();
+          } else {
+            let message = response.statusText || `Code ${response.status}`;
+            try {
+              const errorPayload = await response.json();
+              if(errorPayload && errorPayload.error){
+                message = errorPayload.error;
+              }
+            } catch(_){}
+            throw new Error(message);
+          }
+          const objectives = Array.isArray(payload) ? payload : [];
+          renderObjectives(objectives);
+          populateObjectiveSelect(objectives);
+          const ts = new Date().toLocaleTimeString('fr-FR', { hour:'2-digit', minute:'2-digit' });
+          setStatus(`Objectifs synchronisés (${ts})`, 'success');
+        } catch(error){
+          console.error('SPHAIRA — chargement impossible', error);
+          setStatus(`Erreur : ${error.message}`, 'error');
+        } finally {
+          loadPromise = null;
+        }
+      })();
+      return loadPromise;
+    }
+
+    async function submitTask(event){
+      event.preventDefault();
+      if(submitButton.disabled) return;
+
+      const formData = new FormData(taskForm);
+      const objectiveId = formData.get('objectiveId');
+      const title = formData.get('title').trim();
+      if(!objectiveId || !title){
+        setStatus('Sélectionnez un objectif et renseignez un titre de tâche.', 'error');
+        return;
+      }
+
+      submitButton.disabled = true;
+      const previousLabel = submitButton.textContent;
+      submitButton.textContent = 'Enregistrement…';
+
+      try {
+        const response = await fetch(`${API_BASE}/objectives`);
+        let payload;
+        if(response.ok){
+          payload = await response.json();
+        } else {
+          let message = response.statusText || `Code ${response.status}`;
+          try {
+            const errorPayload = await response.json();
+            if(errorPayload && errorPayload.error){
+              message = errorPayload.error;
+            }
+          } catch(_){}
+          throw new Error(message);
+        }
+
+        const objectives = Array.isArray(payload) ? payload : [];
+        const target = objectives.find(obj => obj.id === objectiveId);
+        if(!target){
+          throw new Error('Objectif introuvable dans la source partagée.');
+        }
+
+        const newTask = {
+          id: `task-${Math.random().toString(36).slice(2,8)}${Date.now().toString(36).slice(-2)}`,
+          title,
+          owner: formData.get('owner').trim(),
+          due: formData.get('due'),
+          done: formData.get('status') === 'done'
+        };
+
+        if(!Array.isArray(target.tasks)){
+          target.tasks = [];
+        }
+        target.tasks.push(newTask);
+
+        const updateResponse = await fetch(`${API_BASE}/objectives/${encodeURIComponent(target.id)}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(target)
+        });
+        if(!updateResponse.ok){
+          let message = updateResponse.statusText || `Code ${updateResponse.status}`;
+          try {
+            const errorPayload = await updateResponse.json();
+            if(errorPayload && errorPayload.error){
+              message = errorPayload.error;
+            }
+          } catch(_){}
+          throw new Error(message);
+        }
+
+        taskForm.reset();
+        setStatus(`Tâche ajoutée à « ${target.title} ».`, 'success');
+        await loadObjectives();
+      } catch(error){
+        console.error('SPHAIRA — création de tâche impossible', error);
+        setStatus(`Erreur lors de la création de la tâche : ${error.message}`, 'error');
+      } finally {
+        submitButton.disabled = false;
+        submitButton.textContent = previousLabel;
+      }
+    }
+
+    taskForm.addEventListener('submit', submitTask);
+    window.addEventListener('sphaira:objectives', () => { loadObjectives(); });
+    window.addEventListener('storage', (event) => {
+      if(event.key === STORAGE_KEY){
+        loadObjectives();
+      }
+    });
+
+    loadObjectives();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- replace the static objective dataset in Ecliptica with an asynchronous loader that fetches from the shared SPHAIRA data source and reuses it for create/update/delete flows
- add a shared in-memory bridge that emulates the SPHAIRA REST API so both clients persist to the same storage and broadcast updates
- introduce a lightweight SPHAIRA console to review objectives and push new tasks into the shared store so Ecliptica stays in sync

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d658ee562c833391e8ef0f02ddce52